### PR TITLE
Check if version name is not none in obfdiff_config.py

### DIFF
--- a/tools/objdiff_config.py
+++ b/tools/objdiff_config.py
@@ -4,7 +4,6 @@ import json
 import copy
 
 from pathlib import Path
-from typing import Optional
 
 
 class ConfigUnit:
@@ -19,7 +18,7 @@ class ConfigUnit:
 
 
 class ConfigVersion:
-    def __init__(self, name: Optional[str], options: dict[str, str], units: list[ConfigUnit], root_path: Path):
+    def __init__(self, name: str, options: dict[str, str], units: list[ConfigUnit], root_path: Path):
         self.name = name
         self.objdiff_path = Path(options["objdiff"]).resolve()
 
@@ -32,7 +31,7 @@ class ConfigVersion:
         self.objdiff_json.pop("build_base")
 
         for i, unit_dict in enumerate(objdiff_json["units"]):
-            if "name" in unit_dict and self.name is not None:
+            if "name" in unit_dict:
                 unit_dict["name"] = f"{self.name}/{unit_dict['name']}"
 
             def get_cleaned_path(base_path: Path):
@@ -57,10 +56,7 @@ class ConfigVersion:
 
                 entry = self.get_entry_from_name(units, self.objdiff_json["units"][i]["name"])
                 if entry is not None:
-                    cflags = entry.get_all_cflags()
-                    if self.name is not None:
-                        cflags += f" -DVERSION={self.name.upper()}"
-                    self.objdiff_json["units"][i]["scratch"]["c_flags"] = cflags
+                    self.objdiff_json["units"][i]["scratch"]["c_flags"] = f"{entry.get_all_cflags()} -DVERSION={self.name.upper()}"
                     self.objdiff_json["units"][i]["scratch"]["compiler"] = entry.mw_version
 
     def get_entry_from_name(self, units: list[ConfigUnit], base_name: str):
@@ -100,9 +96,8 @@ class ObjdiffConfig:
         for name, options in cfg_json["units"].items():
             units.append(ConfigUnit(name, options))
 
-        multi_version = len(cfg_json["versions"].items()) > 1
         for name, options in cfg_json["versions"].items():
-            cfg.versions.append(ConfigVersion(name if multi_version else None, options, units, cfg.root_path))
+            cfg.versions.append(ConfigVersion(name, options, units, cfg.root_path))
 
         return cfg
 

--- a/tools/objdiff_config.py
+++ b/tools/objdiff_config.py
@@ -57,7 +57,10 @@ class ConfigVersion:
 
                 entry = self.get_entry_from_name(units, self.objdiff_json["units"][i]["name"])
                 if entry is not None:
-                    self.objdiff_json["units"][i]["scratch"]["c_flags"] = f"{entry.get_all_cflags()} -DVERSION={self.name.upper()}"
+                    cflags = entry.get_all_cflags()
+                    if self.name is not None:
+                        cflags += f" -DVERSION={self.name.upper()}"
+                    self.objdiff_json["units"][i]["scratch"]["c_flags"] = cflags
                     self.objdiff_json["units"][i]["scratch"]["compiler"] = entry.mw_version
 
     def get_entry_from_name(self, units: list[ConfigUnit], base_name: str):


### PR DESCRIPTION
Hello,

I encountered a bug when executing `ninja` after configuring the project. I have `arm{7,9}_bios.bin` and `baserom_st_eur.nds`, whose SHA-1 hashes all match indicated ones.

Here's the stacktrace of the error :
```python
↪ ninja
[1/1] /usr/bin/python3.14 tools/configure.py -w /usr/bin/wine
[3/13] /usr/bin/python3.14 tools/objdiff_config.py
FAILED: [code=1] objdiff
/usr/bin/python3.14 tools/objdiff_config.py
Traceback (most recent call last):
  File "/home/user/Documents/Zelda/st/tools/objdiff_config.py", line 117, in <module>
    main()
    ~~~~^^
  File "/home/user/Documents/Zelda/st/tools/objdiff_config.py", line 108, in main
    cfg = ObjdiffConfig.new("build/objdiff_cfg.json")
  File "/home/user/Documents/Zelda/st/tools/objdiff_config.py", line 102, in new
    cfg.versions.append(ConfigVersion(name if multi_version else None, options, units, cfg.root_path))
                        ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Documents/Zelda/st/tools/objdiff_config.py", line 60, in __init__
    self.objdiff_json["units"][i]["scratch"]["c_flags"] = f"{entry.get_all_cflags()} -DVERSION={self.name.upper()}"
                                                                                                ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'upper'
[...]
```

Here's the list of executed commands :
```sh
/bin/python3 -m pip install -r tools/requirements.txt --break-system-packages
/bin/python3 tools/configure.py -w '/usr/bin/wine'
ninja
```

The PR just checks if the variable `self.name` in `ConfigVersion` is not None before using it to define a macro in C flags.

I'm not sure if it's a good way to fix the error for the project (what happens if the macro isn't defined ?) and how to actually test it, but `ninja` returns 0 as an exit code and all checks log OK so i guess it's fine.

Cheers.