### PR TITLE
Create a `CMakeLists.txt` to generate `compile_commands.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 build/
 .vscode/
+.clangd
+cmake/
+compile_commands.json
 ph_*/
 *.nds
 *bios.bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,4 @@
+# See CONTRIBUTING.md for explanations
 # Adapted from https://gist.github.com/Strus/042a92a00070a943053006bf46912ae9
 # Build the compilation database with `cmake -S . -G "Unix Makefiles" -B cmake`
 # The database is exported in the cmake/ directory
@@ -28,11 +29,10 @@ file(GLOB lib_paths
 
 foreach(path IN LISTS lib_paths)
 
+    # Retrieve the name of the lib
     string(REGEX MATCH "([a-z]+)$" lib_name ${path}) # last word of the path is the name
-    # message(STATUS "path=${path}")
-    # message(STATUS "name=${lib_name}")
 
-    # Add the library only as an interface since we don't plan on compiling anyway
+    # Add the library as an interface only since we don't intend on actually compiling anyway
     add_library(${lib_name} INTERFACE)
     set_target_properties(${lib_name} PROPERTIES
           INTERFACE_INCLUDE_DIRECTORIES "${path}/include"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # The database is exported in the cmake/ directory
 
 cmake_minimum_required(VERSION 3.8)
-project(st_eur)
+project(st_decomp)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -17,10 +17,10 @@ file(GLOB_RECURSE sources
 # Add precompiler definitions like that:
 # add_definitions(-DSOME_DEFINITION)
 
-add_executable(st_eur ${sources})
+add_executable(st_decomp ${sources})
 
 # Add include directories
-target_include_directories(st_eur PUBLIC "${CMAKE_SOURCE_DIR}/include")
+target_include_directories(st_decomp PUBLIC "${CMAKE_SOURCE_DIR}/include")
 
 # Add lib directories
 file(GLOB lib_paths
@@ -38,9 +38,9 @@ foreach(path IN LISTS lib_paths)
           INTERFACE_INCLUDE_DIRECTORIES "${path}/include"
     )
 
-    target_link_libraries(st_eur ${lib_name}) # also adds the required include path
+    target_link_libraries(st_decomp ${lib_name}) # also adds the required include path
 
 endforeach()
 
 # If you have precompiled headers you can add them like this
-# trget_precompiled_headers(st_eur PRIVATE "${CMAKE_SOURCE_DIR}/src/pch.h")
+# trget_precompiled_headers(st_decomp PRIVATE "${CMAKE_SOURCE_DIR}/src/pch.h")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Adapted from https://gist.github.com/Strus/042a92a00070a943053006bf46912ae9
+# Build the compilation database with `cmake -S . -G "Unix Makefiles" -B cmake`
+# The database is exported in the cmake/ directory
+
+cmake_minimum_required(VERSION 3.8)
+project(st_eur)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Change path from /src if needed, or add more directories
+file(GLOB_RECURSE sources
+        "${CMAKE_SOURCE_DIR}/src/*.c"
+        "${CMAKE_SOURCE_DIR}/src/*.cpp"
+)
+
+# Add precompiler definitions like that:
+# add_definitions(-DSOME_DEFINITION)
+
+add_executable(st_eur ${sources})
+
+# Add include directories
+target_include_directories(st_eur PUBLIC "${CMAKE_SOURCE_DIR}/include")
+
+# Add lib directories
+file(GLOB lib_paths
+        "${CMAKE_SOURCE_DIR}/libs/*"
+)
+
+foreach(path IN LISTS lib_paths)
+
+    string(REGEX MATCH "([a-z]+)$" lib_name ${path}) # last word of the path is the name
+    # message(STATUS "path=${path}")
+    # message(STATUS "name=${lib_name}")
+
+    # Add the library only as an interface since we don't plan on compiling anyway
+    add_library(${lib_name} INTERFACE)
+    set_target_properties(${lib_name} PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${path}/include"
+    )
+
+    target_link_libraries(st_eur ${lib_name}) # also adds the required include path
+
+endforeach()
+
+# If you have precompiled headers you can add them like this
+# trget_precompiled_headers(st_eur PRIVATE "${CMAKE_SOURCE_DIR}/src/pch.h")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,6 +6,7 @@ Contents:
 - [Build the ROM](#build-the-rom)
     - [Matching the base ROM](#matching-the-base-rom)
     - [Building with non-matching code](#building-with-non-matching-code)
+- [[Optional] LSP setup](#lsp-setup)
 
 ## Prerequisites
 
@@ -50,3 +51,16 @@ ARM7 BIOS in the root directory of this repository, and verify that your dumped 
 | --------------- | ------------------------------------------ |
 | `arm7_bios.bin` | `6ee830c7f552c5bf194c20a2c13d5bb44bdb5c03` |
 | `arm7_bios.bin` | `24f67bdea115a2c847c8813a262502ee1607b7df` |
+
+## LSP setup
+
+**This is likely not necessary.** Most C++ editors usually have their one LSP configuration that should recognize the project structure and work out of the box. This section is about how to setup your LSP yourself **if the need be**.
+
+The repository contains a [`CMakeLists.txt`](CMakeLists.txt) that allows generating a compilation database. For now, the `CMakeLists.txt` can only be used to generate `compile_commands.json` and similar files, not compiling the project.  
+To generate the compilation database, run `cmake -S . -G "Unix Makefiles" -B cmake` from the root directory of the project. This will create a `cmake/` directory that contains the `compile_commands.json`.  
+Once the file is generated, you can dynamically link it to the root directory and let your LSP detect it, or edit your `.clangd` as follows for it to recognize the compilation database:
+```clangd
+CompileFlags:
+    CompilationDatabase: "cmake"
+```
+This setup is adapted from a [tutorial by Strus](https://gist.github.com/Strus/042a92a00070a943053006bf46912ae9), refer to his post for further details.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -54,11 +54,11 @@ ARM7 BIOS in the root directory of this repository, and verify that your dumped 
 
 ## LSP setup
 
-**This is likely not necessary.** Most C++ editors usually have their one LSP configuration that should recognize the project structure and work out of the box. This section is about how to setup your LSP yourself **if the need be**.
+**This is likely not necessary.** Most C++ editors usually have their one LSP (Language Server Protocol, a tool for code completion and more) configuration that should recognize the project structure and work out of the box. This section is about how to setup your LSP yourself **if the need be**.
 
 The repository contains a [`CMakeLists.txt`](CMakeLists.txt) that allows generating a compilation database. For now, the `CMakeLists.txt` can only be used to generate `compile_commands.json` and similar files, not compiling the project.  
 To generate the compilation database, run `cmake -S . -G "Unix Makefiles" -B cmake` from the root directory of the project. This will create a `cmake/` directory that contains the `compile_commands.json`.  
-Once the file is generated, you can dynamically link it to the root directory and let your LSP detect it, or edit your `.clangd` as follows for it to recognize the compilation database:
+Once the file is generated, you can dynamically link it to the root directory and let your LSP detect it (make sure not to `git add` it though), or edit your `.clangd` as follows for it to recognize the compilation database:
 ```clangd
 CompileFlags:
     CompilationDatabase: "cmake"


### PR DESCRIPTION
Even though most widespread editors will deal just fine with the configuration of the LSP for this project, it may still be useful to be able to generate the `compile_commands.json` (for a custom configuration, other editor or anything else).

I added a `CMakeLists.txt` with generating the `compile_commands.json` as its sole purpose (there is not compilation goal). It can then be used to setup an LSP manually for example.  
I added some doc about the (optional) configuration of the LSP in this way and how to generate the `compile_commands.json` file (it uses a specific `cmake` command).

Let me know if this would be useful for the project and if there are additional modifications to make. For example, edit the .gitignore to exclude `cmake/` from the repo (the compilation database is created inside `repo_root/cmake/`), and maybe also exclude `.clangd` files (although they can be put outside of the repo with no bad consequences for the user).